### PR TITLE
docs: fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Hello, and welcome to SPIRE examples!
 
-This repository houses various SPIFFE/SPIRE deployment and integration examples. All examples are self contained, and come with instructions on how to use them.
+This repository houses various SPIFFE/SPIRE deployment and integration examples. All examples are self-contained and come with instructions on how to use them.
 
 The SPIRE project is growing rapidly, and new features are released often. In order to ensure the accuracy of accompanying documentation, each example is written against a specific version of SPIRE. All examples are regularly tested against the stated SPIRE version, but are likely to work with newer versions as well.
 
@@ -12,7 +12,7 @@ The SPIRE project is growing rapidly, and new features are released often. In or
 
 Examples showing how SPIRE integrates with Envoy.
 
-* [Envoy SDS Integration](examples/envoy) Use SPIRE to deliver and rotate X509-SVIDs for Envoy
+* [Envoy SDS Integration](examples/envoy) - Use SPIRE to deliver and rotate X509-SVIDs for Envoy
 
 ## Kubernetes
 


### PR DESCRIPTION
## Summary
- clarify README wording
- fix Envoy bullet formatting

## Testing
- `examples/k8s/test-all.sh` *(fails: kubectl is required)*

------
https://chatgpt.com/codex/tasks/task_b_689066af19cc832fa5b862f3e34bd4a4